### PR TITLE
hikey: set CC_PREFIX before using it

### DIFF
--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -110,8 +110,8 @@ case $1 in
                     ;;
             esac
         else
-            LIBCBASE=${CC_DIR}/${CC_PREFIX}/libc
             CC_PREFIX=aarch64-linux-gnu
+            LIBCBASE=${CC_DIR}/${CC_PREFIX}/libc
             export ARCH=arm64
         fi
 


### PR DESCRIPTION
This fixes a bug introduced by commit 562ba7fb0fc4 ("hikey: use
${CROSS_COMPILE} if set") when CROSS_COMPILE is _not_ set.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
