### PR TITLE
hikey: Set CC_PREFIX correctly when using repo

### DIFF
--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -110,8 +110,8 @@ case $1 in
                     ;;
             esac
         else
-            LIBCBASE=${CC_DIR}/${CC_PREFIX}/libc
             CC_PREFIX=aarch64-linux-gnu
+            LIBCBASE=${CC_DIR}/${CC_PREFIX}/libc
             export ARCH=arm64
         fi
 


### PR DESCRIPTION
Two lines was swapped by mistake and therefore CC_PREFIX didn't have any
value for the LIBCBASE variable and as a result the script failed to
build the filesystem.

Signed-off-by: Joakim Bech joakim.bech@linaro.org
