### PR TITLE
hikey: enable uart3

### DIFF
--- a/etc/inittab-hikey
+++ b/etc/inittab-hikey
@@ -2,7 +2,9 @@
 # /etc/inittab
 #
 ::sysinit:/etc/init.d/rc.init
+# HiKey defaults to UART3 but can also use UART0
 ttyAMA0::askfirst:/bin/sh -sc ". /etc/profile"
+ttyAMA3::askfirst:/bin/sh -sc ". /etc/profile"
 ::ctrlaltdel:/sbin/poweroff
 ::shutdown:/etc/init.d/rc.shutdown
 ::restart:/sbin/init

--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -115,7 +115,7 @@ case $1 in
             export ARCH=arm64
         fi
 
-        cp etc/inittab-vexpress etc/inittab
+        cp etc/inittab-hikey etc/inittab
         echo "HiKey" > etc/hostname
         ;;
 


### PR DESCRIPTION
hikey uses uart3 as default console so enable it in inittab

Signed-off-by: Victor Chong victor.chong@linaro.org
