### PR TITLE
Return an error in case busybox is not compiling

### DIFF
--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -6,6 +6,9 @@
 #
 # All credits to Linus Walleij that wrote this initially.
 
+# exit as soon as an error is encoutered
+set -e
+
 echo "Generator for a simple initramfs root filesystem for some ARM targets"
 CURDIR="$(dirname "$(readlink -f "$0")")"
 STAGEDIR=${CURDIR}/stage


### PR DESCRIPTION
Even when busybox is not compiling correctly,
generate-cpio-rootfs.sh does not return an error.
This is now fixed

Signed-off-by: Pascal Brand pascal.brand@st.com
