### PR TITLE
Fix unknown option to 's' error for some projects

### DIFF
--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -214,7 +214,7 @@ if [ ! -e ${BUILDDIR}/.config ]; then
   echo "Configuring cross compiler etc..."
   # Comment in this line to create a statically linked busybox
   #sed -i "s/^#.*CONFIG_STATIC.*/CONFIG_STATIC=y/" ${BUILDDIR}/.config
-  sed -i -e "s/CONFIG_CROSS_COMPILER_PREFIX=\"\"/CONFIG_CROSS_COMPILER_PREFIX=\"${CROSS_COMPILE}\"/g" ${BUILDDIR}/.config
+  sed -i -e "s|CONFIG_CROSS_COMPILER_PREFIX=\"\"|CONFIG_CROSS_COMPILER_PREFIX=\"${CROSS_COMPILE}\"|g" ${BUILDDIR}/.config
   sed -i -e "s/CONFIG_EXTRA_CFLAGS=\"\"/CONFIG_EXTRA_CFLAGS=\"${CFLAGS}\"/g" ${BUILDDIR}/.config
   sed -i -e "s/CONFIG_PREFIX=\".*\"/CONFIG_PREFIX=\"..\/stage\"/g" ${BUILDDIR}/.config
   # Turn off "eject" command, we don't have a CDROM


### PR DESCRIPTION
This fixes below error for some projects, namely hikey_optee.
sed: -e expression #1, char 73: unknown option to 's'

Signed-off-by: Victor Chong victor.chong@linaro.org
