### PR TITLE
Fix ccache error when ccache is not installed

### DIFF
--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -152,14 +152,8 @@ else
     echo "Set up cross compiler at: ${CC_DIR}"
     export PATH="${CC_DIR}/bin:${PATH}"
 
-    echo -n "Check ccache ..."
-    which ccache > /dev/null ; if [ ! $? -eq 0 ] ; then
-        echo "No"
-    else
-        echo "Yes"
-        # Set $CCACHE to "ccache " only if unset
-        CCACHE=${CCACHE-ccache }
-    fi
+    # Set $CCACHE to "ccache " only if unset and ccache is installed
+    which ccache > /dev/null && CCACHE=${CCACHE-ccache } || true
 fi
 
 echo "OUTFILE = ${OUTFILE}"


### PR DESCRIPTION
This fixes the build issue encountered in
https://github.com/OP-TEE/optee_os/issues/672

Signed-off-by: Pascal Brand pascal.brand@st.com
