### PR TITLE
Exclude unused large libs from rootfs

### DIFF
--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -195,7 +195,10 @@ for file in ${SBINFILES} ; do
     echo "file /sbin/${BASE} $file 755 0 0" >> filelist-tmp.txt
 done;
 
-LIBFILES=`find ${STAGEDIR}/lib -maxdepth 1 -type f -a -not -name "*.a"`
+LIBFILES=`find ${STAGEDIR}/lib -maxdepth 1 -type f -a -not -name "*.a" \
+	-a -not -name "libstdc++*" -a -not -name "libasan*" \
+	-a -not -name "libubsan*" -a -not -name "libgfortran*" \
+	-a -not -name "libnss_nis*"`
 for file in ${LIBFILES} ; do
     BASE=`basename $file`
     echo "file /lib/${BASE} $file 755 0 0" >> filelist-tmp.txt


### PR DESCRIPTION
Excludes currently unused large libs from the generated rootfs.

Tested-by: Jens Wiklander jens.wiklander@linaro.org (Juno)
Signed-off-by: Jens Wiklander jens.wiklander@linaro.org
