### PR TITLE
Add alias for virtfs share mount

### DIFF
--- a/etc/profile
+++ b/etc/profile
@@ -15,3 +15,4 @@ if [ -e "/etc/profile.local" ]; then
 fi
 
 alias ll='ls -al'
+alias mount_shared='mount -t 9p -o trans=virtio host'


### PR DESCRIPTION
Add alias for convenient virtfs share mount
Relates to https://github.com/OP-TEE/build/pull/79

Signed-off-by: Igor Opaniuk igor.opaniuk@linaro.org
