### PR TITLE
Remove big unused files from gcc6x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ filesystem.cpio.gz
 rootfs-fvp-aarch64.cpio
 rootfs-hikey.cpio
 rootfs-vexpress.cpio
+rootfs-mt8173-evb.cpio

--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -209,7 +209,8 @@ done;
 LIBFILES=`find ${STAGEDIR}/lib -maxdepth 1 -type f -a -not -name "*.a" \
 	-a -not -name "libstdc++*" -a -not -name "libasan*" \
 	-a -not -name "libubsan*" -a -not -name "libgfortran*" \
-	-a -not -name "libnss_nis*"`
+	-a -not -name "libnss_nis*" -a -not -name "liblsan*" \
+	-a -not -name "libtsan*" -a -not -name "libitm*"`
 for file in ${LIBFILES} ; do
     BASE=`basename $file`
     echo "file /lib/${BASE} $file 755 0 0" >> filelist-tmp.txt


### PR DESCRIPTION
Once again, there were some new big files when stepping up the toolchain version. Here I'm removing some to ensure that root fs still fits on the devices in use (here it was the MTK8173 that complained about a too big fs).

Also tiny patch adding a cpio to .gitignore.