### PR TITLE
am57xx: tty: add UART ttyS to inittab

### DIFF
--- a/etc/inittab-dra7xx
+++ b/etc/inittab-dra7xx
@@ -4,6 +4,7 @@
 ::sysinit:/etc/init.d/rc.init
 # DRA7xx-EVM defaults to UART3 but can also use UART0
 ttyS0::askfirst:/bin/sh -sc ". /etc/profile"
+ttyS2::askfirst:/bin/sh -sc ". /etc/profile"
 ttyS3::askfirst:/bin/sh -sc ". /etc/profile"
 ::ctrlaltdel:/sbin/poweroff
 ::shutdown:/etc/init.d/rc.shutdown


### PR DESCRIPTION
```
[    2.609564] Serial: 8250/16550 driver, 10 ports, IRQ sharing disabled
[    2.624434] 48020000.serial: ttyS2 at MMIO 0x48020000 (irq = 301, base_baud = 3000000) is a 8250
[    3.674017] console [ttyS2] enabled
[    3.680696] 48422000.serial: ttyS7 at MMIO 0x48422000 (irq = 302, base_baud = 3000000) is a 8250

```
Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>