### PR TITLE
hikey: inittab: spawn login shell only on ${CFG_NW_CONSOLE_UART}

### DIFF
--- a/etc/inittab-hikey
+++ b/etc/inittab-hikey
@@ -2,9 +2,7 @@
 # /etc/inittab
 #
 ::sysinit:/etc/init.d/rc.init
-# HiKey defaults to UART3 but can also use UART0
-ttyAMA0::askfirst:/bin/sh -sc ". /etc/profile"
-ttyAMA3::askfirst:/bin/sh -sc ". /etc/profile"
+ttyAMA${CFG_NW_CONSOLE_UART}::askfirst:/bin/sh -sc ". /etc/profile"
 ::ctrlaltdel:/sbin/poweroff
 ::shutdown:/etc/init.d/rc.shutdown
 ::restart:/sbin/init

--- a/generate-cpio-rootfs.sh
+++ b/generate-cpio-rootfs.sh
@@ -67,6 +67,13 @@ arm-linux-gnueabihf)
     ;;
 esac
 
+function generate_inittab()
+{
+	# Expand variables ${...} taking value from the environment
+	# http://superuser.com/a/302847
+	cat $1 | awk '{while(match($0,"[$]{[^}]*}")) {var=substr($0,RSTART+2,RLENGTH -3);gsub("[$]{"var"}",ENVIRON[var])}}1'>$2
+}
+
 case $1 in
     "vexpress")
         CFLAGS=${CFLAGS-"-Wno-strict-aliasing -Wno-unused-result -marm -mabi=aapcs-linux -mthumb -mthumb-interwork -mcpu=cortex-a15"}
@@ -88,7 +95,8 @@ case $1 in
 
      "hikey")
         echo "Building HiKey root filesystem"
-        cp etc/inittab-hikey etc/inittab
+        export CFG_NW_CONSOLE_UART=${CFG_NW_CONSOLE_UART:-3}
+        generate_inittab etc/inittab-hikey etc/inittab
         echo "HiKey" > etc/hostname
         ;;
 


### PR DESCRIPTION
Currently, etc/inittab-hikey tries to spawn a login shell on both
ttyAMA0 and ttyAMA3 which doesn't work well when secure world and
normal world are configured to use different UARTs (in this case,
secure world won't log any more output as soon as Linux has booted).
This patch generates an inittab file with a single login shell  entry,
based on the value of $CFG_NW_CONSOLE_UART. If not set, ttyAMA3 is
used which is UART1 on the low-speed expension connector.

Fixes: https://github.com/OP-TEE/optee_os/issues/1483
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>